### PR TITLE
Allow discrete inputs at non event mode

### DIFF
--- a/fmpy/simulation.py
+++ b/fmpy/simulation.py
@@ -1287,7 +1287,7 @@ def simulateCS(model_description, fmu, start_time, stop_time, relative_tolerance
 
         else:
             
-            input.apply(time, continuous=True, discrete=use_event_mode, after_event=use_event_mode)
+            input.apply(time, continuous=True, discrete=True, after_event=use_event_mode)
 
             event_encountered, terminate_simulation, early_return, last_successful_time = fmu.doStep(currentCommunicationPoint=time, communicationStepSize=step_size)
 


### PR DESCRIPTION
For some reason, fmpy only allows discrete inputs in event mode for FMI3, which is not true according to https://fmi-standard.org/docs/3.0.2/#ModelVariables


![Screenshot 2025-04-03 at 10 31 53 AM](https://github.com/user-attachments/assets/f02be4f2-863b-42a3-9a1d-d839449b59e0)
